### PR TITLE
Fix Travis warning

### DIFF
--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -164,7 +164,8 @@ abstract class JHtmlIcon
 			if ($legacy)
 			{
 				$button = JHtml::_('image', 'system/checked_out.png', null, null, true);
-				$text   = '<span class="hasTooltip" title="' . JHtml::tooltipText($tooltip . '', 0) . '">' . $button . '</span> ' . JText::_('JLIB_HTML_CHECKED_OUT');
+				$text   = '<span class="hasTooltip" title="' . JHtml::tooltipText($tooltip . '', 0) . '">'
+					. $button . '</span> ' . JText::_('JLIB_HTML_CHECKED_OUT');
 			}
 			else
 			{


### PR DESCRIPTION
Hi @n9iels,

This should fix the last error found by Travis: https://travis-ci.org/joomla/joomla-cms/jobs/52659140 for https://github.com/joomla/joomla-cms/pull/6248 Can you have a look into it?

```
FILE: .../travis/build/joomla/joomla-cms/components/com_content/helpers/icon.php
--------------------------------------------------------------------------------
FOUND 0 ERROR(S) AND 1 WARNING(S) AFFECTING 1 LINE(S)
--------------------------------------------------------------------------------
 167 | WARNING | Line exceeds 150 characters; contains 154 characters
--------------------------------------------------------------------------------
```